### PR TITLE
Fix the bug that cache-money can't work on Ruby 1.9

### DIFF
--- a/lib/cash/query/abstract.rb
+++ b/lib/cash/query/abstract.rb
@@ -62,8 +62,9 @@ module Cash
 
       def hit_or_miss(cache_keys, index, options)
         misses, missed_keys = nil, nil
-        objects = @active_record.get(cache_keys, options.merge(:ttl => index.ttl)) do |missed_keys|
-          misses = miss(missed_keys, @options1.merge(:limit => index.window))
+        objects = @active_record.get(cache_keys, options.merge(:ttl => index.ttl)) do |missed|
+          missed_keys = missed
+          misses = miss(missed, @options1.merge(:limit => index.window))
           serialize_objects(index, misses)
         end
         [misses, missed_keys, objects]


### PR DESCRIPTION
This code leverages a bug in Ruby 1.8 to evaluate. But this code can't work in 1.9, So I fixed it.
